### PR TITLE
Added client options for extending modal window

### DIFF
--- a/ModalForm.php
+++ b/ModalForm.php
@@ -28,6 +28,8 @@ class ModalForm extends Widget
 
     public $options;
 
+    public $clientOptions;
+
     public function init()
     {
         if (! $this->loginUrl && ! empty(\Yii::$app->user->loginUrl)) {
@@ -44,11 +46,12 @@ class ModalForm extends Widget
     public function run()
     {
         $options = json_encode($this->options);
+        $clientOptions = json_encode($this->clientOptions);
         if ($this->selector) {
             $js = <<<JS
 $('body').on('click', '{$this->selector}', function() {
     var options = $.extend($options, $(this).data());
-    $.createModalForm(options).ajaxContent({url : $(this).attr('href') || $(this).data('url')});;
+    $.createModalForm(options, $clientOptions).ajaxContent({url : $(this).attr('href') || $(this).data('url')});;
     return false;
 });
 JS;

--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ class Controller extends \yii\web\Controller
 }
 ``` 
 
+####Client Options
+To add client options use `clientOptions` key. Available client options are: `id`, `class`, `tabindex`. 
+* Id key **replaces** existing auto generated id attribute. 
+* Class key **adds** classes to html class attribute. 
+* Tabindex key **replaces** existing default tabindex html attribute (-1), when false, then no tabindex attribute appears.
+```
+\conquer\modal\ModalForm::widget([
+    'selector' => '.modal-form',
+    'clientOptions' => [
+        'id' => 'sample-unique-id',
+        'class' => 'sample-class1 sample-class2',
+        'tabindex' => false
+    ]
+]); 
+
 ## License
 
 **conquer/modal** is released under the MIT License. See the bundled `LICENSE` for details.

--- a/assets/modal-form.js
+++ b/assets/modal-form.js
@@ -10,7 +10,7 @@
 
     var self = this;
     
-    $.createModalForm = function(options) {
+    $.createModalForm = function(options, clientOptions) {
         options = $.extend({
             singleton: true,
             size : null,
@@ -37,6 +37,19 @@
         }
         if (options.size) {
             $modalDialog.find('.modal-dialog').addClass(options.size);
+        }
+        if (clientOptions) {
+            if (clientOptions.id) {
+                $modalDialog.attr('id', clientOptions.id);
+            }
+            if (clientOptions.class) {
+                $modalDialog.addClass(clientOptions.class);
+            }
+            if (clientOptions.tabindex) {
+                $modalDialog.attr('tabindex', clientOptions.tabindex);
+            } else if (clientOptions.tabindex == false) {
+                $modalDialog.removeAttr('tabindex');
+            }
         }
         $('body').append($modalDialog);
         var $content = $modalDialog.find('.modal-content');


### PR DESCRIPTION
Added possibility to extend modal window with client options (id, class, tabindex). Main goal was to apply false tabindex attribute because of compatibility with kartik-v/yii2-widget-select2 plugin, which requires no tabindex attribute. 